### PR TITLE
Check `${XDG_CONFIG_HOME:-$HOME/.config}/hosts` before falling back to `$HOME/hosts`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CFLAGS:=-O2 -Wall -Werror -Wpointer-arith -fPIC
 INSTALL_FOLDER:=/lib/x86_64-linux-gnu
-LINK_FOLDER:=/usr/lib/x86_64-linux-gnu
 VERSION:=2
 LIB_NAME:=libnss_homehosts.so
 LIB_NAME_WITH_VERSION:=$(LIB_NAME).$(VERSION)
@@ -21,15 +20,13 @@ clean:
 .PHONY: install
 install: $(LIB_NAME)
 	install -m 644 $< $(INSTALL_FOLDER)
-	rm -f $(INSTALL_FOLDER)/$(LIB_NAME_WITH_VERSION) $(LINK_FOLDER)/$(LIB_NAME)
+	rm -f $(INSTALL_FOLDER)/$(LIB_NAME_WITH_VERSION)
 	ln -s $(LIB_NAME) $(INSTALL_FOLDER)/$(LIB_NAME_WITH_VERSION)
-	ln -s $(INSTALL_FOLDER)/$(LIB_NAME_WITH_VERSION) $(LINK_FOLDER)/$(LIB_NAME)
 	ldconfig
 .PHONY: uninstall
 uninstall:
 	rm -f $(INSTALL_FOLDER)/$(LIB_NAME)
 	rm -f $(INSTALL_FOLDER)/$(LIB_NAME_WITH_VERSION)
-	rm -f $(LINK_FOLDER)/$(LIB_NAME)
 .PHONY: test
 test:
 	echo 198.18.1.1 libnss-homehost.test.example.net >> ~/.hosts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libnss_homehosts
 
-Linux NSS library supports `~/.hosts`, i.e. per-user hosts resolution.
+Linux NSS library supporting per-user hosts resolution using `${XDG_CONFIG_HOME}/hosts` or `~/.hosts`
 
 # Install
 
@@ -12,7 +12,7 @@ $ make
 ```bash
 $ sudo make install
 ```
-* Append NSS module to `/etc/nsswitch.conf`:
+* Preprend the NSS module to the hosts line of `/etc/nsswitch.conf`:
 ```text
 hosts: homehosts files dns
 ```
@@ -36,6 +36,7 @@ $ sudo make uninstall
 $ getent hosts myhost.example.net
 $ ping myhost.example.net
 ```
+Note that looking up the using `host` or `nslookup` will not work as these tools query DNS directly, sidestepping NSS.
 
 # Performance
 

--- a/libnss_homehosts.c
+++ b/libnss_homehosts.c
@@ -31,11 +31,24 @@ typedef int bool;
 #define AFLEN(af) (((af) == AF_INET6) ? sizeof(struct in6_addr) : sizeof(struct in_addr))
 
 #define OPEN_HOME_HOSTS(fh) do { \
+	fh = NULL; \
+	cnt = -1; \
+	c = getenv("XDG_CONFIG_HOME"); \
+	if(c != NULL) \
+		cnt = snprintf(homehosts_file, PATH_MAX, "%s/hosts", c); \
 	c = getenv("HOME"); \
-	cnt = snprintf(homehosts_file, PATH_MAX, "%s/.hosts", c); \
-	if(cnt >= PATH_MAX) goto soft_error; \
-	fh = fopen(homehosts_file, "r"); \
-	if(fh == NULL) goto soft_error; \
+	if(cnt < 0) \
+		cnt = snprintf(homehosts_file, PATH_MAX, "%s/.config/hosts", c); \
+	if(cnt >= 0 && cnt < PATH_MAX) \
+		fh = fopen(homehosts_file, "r"); \
+	\
+	if(fh == NULL) \
+	{ \
+		cnt = snprintf(homehosts_file, PATH_MAX, "%s/.hosts", c); \
+		if(cnt >= PATH_MAX) goto soft_error; \
+		fh = fopen(homehosts_file, "r"); \
+		if(fh == NULL) goto soft_error; \
+	} \
 } while(0)
 
 


### PR DESCRIPTION
Helps reducing clutter in the home directory, while being fully backward compatible: If `${XDG_CONFIG_HOME:${HOME}/.config}/hosts` exists, then it will be used as user hosts file, otherwise `${HOME}/.hosts` will be tried.
I also dropped the symlink creation in `/usr/lib` from the `Makefile`, since it breaks the installation on systems where `/lib` is a symlink to `/usr/lib` (usrmerge), like modern Fedora and Debian systems.